### PR TITLE
feat: implement light write controls — HA light entities with on/off …

### DIFF
--- a/custom_components/hymer_connect/const.py
+++ b/custom_components/hymer_connect/const.py
@@ -74,4 +74,4 @@ CONF_EHG_TOKEN = "ehg_access_token"
 CONF_EHG_REFRESH_TOKEN = "ehg_refresh_token"
 
 # Platforms
-PLATFORMS = ["sensor", "binary_sensor", "device_tracker"]
+PLATFORMS = ["sensor", "binary_sensor", "device_tracker", "light"]

--- a/custom_components/hymer_connect/coordinator.py
+++ b/custom_components/hymer_connect/coordinator.py
@@ -55,6 +55,11 @@ class HymerConnectCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             config_entry=entry,
         )
 
+    @property
+    def signalr_client(self) -> HymerSignalRClient | None:
+        """Return the active SignalR client for sending commands."""
+        return self._signalr
+
     def _on_signalr_update(self, sensor_data: dict[str, Any]) -> None:
         """Handle incoming SignalR sensor data."""
         self._signalr_data.update(sensor_data)

--- a/custom_components/hymer_connect/light.py
+++ b/custom_components/hymer_connect/light.py
@@ -1,0 +1,186 @@
+"""Light platform for HYMER Connect — controllable interior lights."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_COLOR_TEMP,
+    ColorMode,
+    LightEntity,
+    LightEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, MANUFACTURER
+from .coordinator import HymerConnectCoordinator
+from .sensor import _resolve_path
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class HymerLightEntityDescription(LightEntityDescription):
+    bus_id: int
+    on_off_path: str
+    brightness_path: str | None = None
+    color_temp_path: str | None = None
+
+
+LIGHT_DESCRIPTIONS: tuple[HymerLightEntityDescription, ...] = (
+    HymerLightEntityDescription(
+        key="light_living_ceiling",
+        translation_key="light_living_ceiling",
+        bus_id=11,
+        on_off_path="signalr_sensors.light_living_ceiling",
+        brightness_path="signalr_sensors.light_living_ceiling_brightness",
+        icon="mdi:ceiling-light",
+    ),
+    HymerLightEntityDescription(
+        key="light_living_ambient",
+        translation_key="light_living_ambient",
+        bus_id=12,
+        on_off_path="signalr_sensors.light_living_ambient",
+        brightness_path="signalr_sensors.light_living_ambient_brightness",
+        color_temp_path="signalr_sensors.light_living_ambient_color_temp",
+        icon="mdi:wall-sconce-flat",
+    ),
+    HymerLightEntityDescription(
+        key="light_kitchen",
+        translation_key="light_kitchen",
+        bus_id=21,
+        on_off_path="signalr_sensors.light_kitchen",
+        brightness_path="signalr_sensors.light_kitchen_brightness",
+        color_temp_path="signalr_sensors.light_kitchen_color_temp",
+        icon="mdi:ceiling-light",
+    ),
+    HymerLightEntityDescription(
+        key="light_seating_overhead",
+        translation_key="light_seating_overhead",
+        bus_id=43,
+        on_off_path="signalr_sensors.light_seating_overhead",
+        brightness_path="signalr_sensors.light_seating_overhead_brightness",
+        icon="mdi:ceiling-light",
+    ),
+    HymerLightEntityDescription(
+        key="light_bedroom_ambient",
+        translation_key="light_bedroom_ambient",
+        bus_id=15,
+        on_off_path="signalr_sensors.light_bedroom_ambient",
+        icon="mdi:wall-sconce-flat",
+    ),
+    HymerLightEntityDescription(
+        key="light_nightlight",
+        translation_key="light_nightlight",
+        bus_id=16,
+        on_off_path="signalr_sensors.light_nightlight",
+        icon="mdi:lightbulb-night",
+    ),
+    HymerLightEntityDescription(
+        key="light_bathroom_ceiling",
+        translation_key="light_bathroom_ceiling",
+        bus_id=19,
+        on_off_path="signalr_sensors.light_bathroom_ceiling",
+        brightness_path="signalr_sensors.light_bathroom_ceiling_brightness",
+        icon="mdi:ceiling-light",
+    ),
+    HymerLightEntityDescription(
+        key="light_bedroom_overhead",
+        translation_key="light_bedroom_overhead",
+        bus_id=44,
+        on_off_path="signalr_sensors.light_bedroom_overhead",
+        brightness_path="signalr_sensors.light_bedroom_overhead_brightness",
+        icon="mdi:ceiling-light",
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator: HymerConnectCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        HymerConnectLight(coordinator, desc, entry)
+        for desc in LIGHT_DESCRIPTIONS
+    )
+
+
+class HymerConnectLight(
+    CoordinatorEntity[HymerConnectCoordinator], LightEntity
+):
+    entity_description: HymerLightEntityDescription
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: HymerConnectCoordinator,
+        description: HymerLightEntityDescription,
+        entry: ConfigEntry,
+    ) -> None:
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{entry.entry_id}_{description.key}"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, entry.entry_id)},
+            "name": f"HYMER {entry.title}",
+            "manufacturer": MANUFACTURER,
+            "model": "Smart Interface Unit",
+        }
+        modes = {ColorMode.ONOFF}
+        if description.brightness_path:
+            modes.add(ColorMode.BRIGHTNESS)
+        self._attr_supported_color_modes = modes
+        self._attr_color_mode = (
+            ColorMode.BRIGHTNESS if ColorMode.BRIGHTNESS in modes else ColorMode.ONOFF
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        if self.coordinator.data is None:
+            return None
+        val = _resolve_path(self.coordinator.data, self.entity_description.on_off_path)
+        if val is None:
+            return None
+        return bool(val)
+
+    @property
+    def brightness(self) -> int | None:
+        if not self.entity_description.brightness_path:
+            return None
+        if self.coordinator.data is None:
+            return None
+        val = _resolve_path(
+            self.coordinator.data, self.entity_description.brightness_path
+        )
+        if val is None or not isinstance(val, (int, float)):
+            return None
+        return int(val * 255 / 100)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        client = self.coordinator.signalr_client
+        if not client or not client.connected:
+            _LOGGER.warning("Cannot control light - SignalR not connected")
+            return
+        bus = self.entity_description.bus_id
+        if ATTR_BRIGHTNESS in kwargs:
+            pct = int(kwargs[ATTR_BRIGHTNESS] * 100 / 255)
+            await client.send_light_command(bus, 2, uint_value=pct)
+        await client.send_light_command(bus, 1, bool_value=True)
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        client = self.coordinator.signalr_client
+        if not client or not client.connected:
+            _LOGGER.warning("Cannot control light - SignalR not connected")
+            return
+        bus = self.entity_description.bus_id
+        await client.send_light_command(bus, 1, bool_value=False)
+        await self.coordinator.async_request_refresh()

--- a/custom_components/hymer_connect/pia_decoder.py
+++ b/custom_components/hymer_connect/pia_decoder.py
@@ -259,6 +259,80 @@ def build_subscription_requests() -> list[str]:
     return list(_PIA_REQUESTS)
 
 
+def _encode_varint(value: int) -> bytes:
+    """Encode an integer as a protobuf varint."""
+    result = bytearray()
+    while value > 0x7F:
+        result.append((value & 0x7F) | 0x80)
+        value >>= 7
+    result.append(value & 0x7F)
+    return bytes(result)
+
+
+def _encode_field(field_number: int, wire_type: int, data: bytes) -> bytes:
+    """Encode a protobuf field with tag and data."""
+    tag = _encode_varint((field_number << 3) | wire_type)
+    return tag + data
+
+
+def _encode_varint_field(field_number: int, value: int) -> bytes:
+    """Encode a varint field."""
+    return _encode_field(field_number, 0, _encode_varint(value))
+
+
+def _encode_bytes_field(field_number: int, data: bytes) -> bytes:
+    """Encode a length-delimited field."""
+    return _encode_field(field_number, 2, _encode_varint(len(data)) + data)
+
+
+def build_light_command(
+    bus_id: int,
+    sensor_id: int,
+    *,
+    bool_value: bool | None = None,
+    uint_value: int | None = None,
+) -> str:
+    """Build a PiaRequest payload to control a light.
+
+    Args:
+        bus_id: The light's bus ID (e.g. 11 for living ceiling).
+        sensor_id: 1=on/off, 2=brightness, 3=color_temp.
+        bool_value: True/False for on/off (sensor_id=1).
+        uint_value: 0-100 for brightness/color_temp (sensor_id=2,3).
+
+    Returns:
+        Base64-encoded protobuf payload ready to send as PiaRequest argument.
+    """
+    # Build sensor entry: field1=sensor_id, field2=bus_id, field3/5=value
+    sensor_data = _encode_varint_field(1, sensor_id)
+    sensor_data += _encode_varint_field(2, bus_id)
+    if bool_value is not None:
+        sensor_data += _encode_varint_field(5, 1 if bool_value else 0)
+    elif uint_value is not None:
+        sensor_data += _encode_varint_field(3, uint_value)
+
+    # Nest: sensor_data inside field1 of sub2, inside field2 of inner
+    sub2 = _encode_bytes_field(1, sensor_data)
+    inner = _encode_bytes_field(2, sub2)
+    command = _encode_bytes_field(2, inner)  # field 4 placeholder → using field 2
+
+    # Build wrapper: msg_id, version, timestamp, command
+    import random
+    msg_id = random.randint(1, 10_000_000)
+    version_bytes = b"v0.32.0"
+    ts = int(time.time())
+
+    wrapper = _encode_varint_field(1, msg_id)
+    wrapper += _encode_bytes_field(2, version_bytes)
+    wrapper += _encode_varint_field(3, ts)
+    wrapper += _encode_bytes_field(4, inner)
+
+    # Top-level: field 2 = wrapper
+    payload = _encode_bytes_field(2, wrapper)
+
+    return base64.b64encode(payload).decode("ascii")
+
+
 def _decode_varint(data: bytes, pos: int) -> tuple[int, int]:
     """Decode a varint, return (value, new_pos)."""
     result = 0

--- a/custom_components/hymer_connect/signalr_client.py
+++ b/custom_components/hymer_connect/signalr_client.py
@@ -15,7 +15,7 @@ import aiohttp
 
 from .api import HymerConnectApi, HymerConnectApiError
 from .const import USER_AGENT
-from .pia_decoder import build_subscription_requests, decode_pia_payload
+from .pia_decoder import build_subscription_requests, decode_pia_payload, build_light_command
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -394,6 +394,31 @@ class HymerSignalRClient:
         await self._ws.send_str(
             json.dumps(msg) + SIGNALR_RECORD_SEPARATOR
         )
+
+    async def send_light_command(
+        self,
+        bus_id: int,
+        sensor_id: int,
+        *,
+        bool_value: bool | None = None,
+        uint_value: int | None = None,
+    ) -> None:
+        """Send a light control command to the SCU.
+
+        Args:
+            bus_id: Light bus ID (e.g. 11 for living ceiling).
+            sensor_id: 1=on/off, 2=brightness, 3=color_temp.
+            bool_value: True/False for on/off.
+            uint_value: 0-100 for brightness/color_temp.
+        """
+        payload = build_light_command(
+            bus_id, sensor_id, bool_value=bool_value, uint_value=uint_value
+        )
+        _LOGGER.info(
+            "Sending light command: bus=%d sid=%d bool=%s uint=%s",
+            bus_id, sensor_id, bool_value, uint_value,
+        )
+        await self.send_pia_request(payload)
 
     async def start(self) -> None:
         """Connect and start listening in the background."""

--- a/custom_components/hymer_connect/strings.json
+++ b/custom_components/hymer_connect/strings.json
@@ -97,6 +97,16 @@
       "fridge_status": { "name": "Fridge status" },
       "fresh_water_level": { "name": "Fresh water level" }
     },
+    "light": {
+      "light_living_ceiling": { "name": "Living ceiling" },
+      "light_living_ambient": { "name": "Living ambient" },
+      "light_kitchen": { "name": "Kitchen" },
+      "light_seating_overhead": { "name": "Seating overhead" },
+      "light_bedroom_ambient": { "name": "Bedroom ambient" },
+      "light_nightlight": { "name": "Night light" },
+      "light_bathroom_ceiling": { "name": "Bathroom ceiling" },
+      "light_bedroom_overhead": { "name": "Bedroom overhead" }
+    },
     "binary_sensor": {
       "engine_running": { "name": "Engine" },
       "handbrake": { "name": "Handbrake" },

--- a/custom_components/hymer_connect/translations/en.json
+++ b/custom_components/hymer_connect/translations/en.json
@@ -316,6 +316,32 @@
       "light_bedroom_overhead": {
         "name": "Bedroom overhead light"
       }
+    },
+    "light": {
+      "light_living_ceiling": {
+        "name": "Living ceiling"
+      },
+      "light_living_ambient": {
+        "name": "Living ambient"
+      },
+      "light_kitchen": {
+        "name": "Kitchen"
+      },
+      "light_seating_overhead": {
+        "name": "Seating overhead"
+      },
+      "light_bedroom_ambient": {
+        "name": "Bedroom ambient"
+      },
+      "light_nightlight": {
+        "name": "Night light"
+      },
+      "light_bathroom_ceiling": {
+        "name": "Bathroom ceiling"
+      },
+      "light_bedroom_overhead": {
+        "name": "Bedroom overhead"
+      }
     }
   }
 }


### PR DESCRIPTION
…and brightness (#23)

New light.py platform with 8 controllable LightEntity instances:
- turn_on/turn_off via PiaRequest protobuf commands to SCU
- brightness control (0-100%) mapped to HA 0-255 scale
- send_light_command() added to signalr_client.py
- build_light_command() protobuf encoder added to pia_decoder.py
- signalr_client property exposed on coordinator
- Light platform registered in const.py PLATFORMS
- Translations added for light entities

Bus mapping: 11=living ceiling, 12=living ambient, 21=kitchen, 43=seating overhead, 15=bedroom ambient, 16=nightlight, 19=bathroom ceiling, 44=bedroom overhead