### PR TITLE
Add button and number platforms (wake chassis, refresh tanks, fridge cooling level)

### DIFF
--- a/custom_components/hymer_connect/button.py
+++ b/custom_components/hymer_connect/button.py
@@ -1,0 +1,109 @@
+"""Button platform for HYMER Connect — one-shot commands to the SCU."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, MANUFACTURER
+from .coordinator import HymerConnectCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class HymerButtonEntityDescription(ButtonEntityDescription):
+    """Describe a HYMER Connect button — a write-only SCU command."""
+
+    bus_id: int
+    sensor_id: int
+
+
+# These slots are write-only in the SCU's capability surface: sending a
+# boolean true pokes the SCU to do something (wake the chassis over cellular,
+# force an immediate fresh water-tank read, etc.) rather than flipping a
+# long-lived toggle. Pressing the button posts a single command; there is no
+# corresponding read-back value.
+BUTTON_DESCRIPTIONS: tuple[HymerButtonEntityDescription, ...] = (
+    HymerButtonEntityDescription(
+        key="wake_up_chassis_ctrl",
+        translation_key="wake_up_chassis_ctrl",
+        bus_id=30,
+        sensor_id=11,
+        icon="mdi:sleep-off",
+    ),
+    HymerButtonEntityDescription(
+        key="update_tank_level_immediately_ctrl",
+        translation_key="update_tank_level_immediately_ctrl",
+        bus_id=3,
+        sensor_id=21,
+        icon="mdi:water-sync",
+    ),
+    HymerButtonEntityDescription(
+        key="activate_tank_refill_interval_ctrl",
+        translation_key="activate_tank_refill_interval_ctrl",
+        bus_id=3,
+        sensor_id=20,
+        icon="mdi:water-pump",
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up HYMER Connect buttons from a config entry."""
+    coordinator: HymerConnectCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        HymerConnectButton(coordinator, desc, entry)
+        for desc in BUTTON_DESCRIPTIONS
+    )
+
+
+class HymerConnectButton(
+    CoordinatorEntity[HymerConnectCoordinator], ButtonEntity
+):
+    """Representation of a HYMER Connect button."""
+
+    entity_description: HymerButtonEntityDescription
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: HymerConnectCoordinator,
+        description: HymerButtonEntityDescription,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the button."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{entry.entry_id}_{description.key}"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, entry.entry_id)},
+            "name": f"HYMER {entry.title}",
+            "manufacturer": MANUFACTURER,
+            "model": "Smart Interface Unit",
+        }
+
+    async def async_press(self) -> None:
+        """Fire the write-only command."""
+        client = self.coordinator.signalr_client
+        if not client or not client.connected:
+            _LOGGER.warning(
+                "Cannot press %s — SignalR not connected",
+                self.entity_description.key,
+            )
+            return
+        await client.send_light_command(
+            self.entity_description.bus_id,
+            self.entity_description.sensor_id,
+            bool_value=True,
+        )

--- a/custom_components/hymer_connect/const.py
+++ b/custom_components/hymer_connect/const.py
@@ -74,4 +74,12 @@ CONF_EHG_TOKEN = "ehg_access_token"
 CONF_EHG_REFRESH_TOKEN = "ehg_refresh_token"
 
 # Platforms
-PLATFORMS = ["sensor", "binary_sensor", "device_tracker", "light", "switch"]
+PLATFORMS = [
+    "sensor",
+    "binary_sensor",
+    "device_tracker",
+    "light",
+    "switch",
+    "button",
+    "number",
+]

--- a/custom_components/hymer_connect/number.py
+++ b/custom_components/hymer_connect/number.py
@@ -1,0 +1,140 @@
+"""Number platform for HYMER Connect — integer-valued SCU controls."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from homeassistant.components.number import (
+    NumberEntity,
+    NumberEntityDescription,
+    NumberMode,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, MANUFACTURER
+from .coordinator import HymerConnectCoordinator
+from .sensor import _resolve_path
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class HymerNumberEntityDescription(NumberEntityDescription):
+    """Describe a HYMER Connect number control."""
+
+    bus_id: int
+    sensor_id: int
+    value_path: str
+
+
+NUMBER_DESCRIPTIONS: tuple[HymerNumberEntityDescription, ...] = (
+    # Fridge cooling level (1..5). The SCU encodes this as a uint step value
+    # and the app's picker only exposes the integer steps, so restrict the
+    # HA entity to that range with step=1.
+    HymerNumberEntityDescription(
+        key="fridge_level_ctrl",
+        translation_key="fridge_level_ctrl",
+        bus_id=34,
+        sensor_id=3,
+        value_path="signalr_sensors.fridge_level",
+        native_min_value=1,
+        native_max_value=5,
+        native_step=1,
+        mode=NumberMode.SLIDER,
+        icon="mdi:fridge",
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up HYMER Connect number entities from a config entry."""
+    coordinator: HymerConnectCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        HymerConnectNumber(coordinator, desc, entry)
+        for desc in NUMBER_DESCRIPTIONS
+    )
+
+
+class HymerConnectNumber(
+    CoordinatorEntity[HymerConnectCoordinator], NumberEntity
+):
+    """Representation of a HYMER Connect numeric control."""
+
+    entity_description: HymerNumberEntityDescription
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: HymerConnectCoordinator,
+        description: HymerNumberEntityDescription,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the number."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{entry.entry_id}_{description.key}"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, entry.entry_id)},
+            "name": f"HYMER {entry.title}",
+            "manufacturer": MANUFACTURER,
+            "model": "Smart Interface Unit",
+        }
+        self._optimistic_value: float | None = None
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current value, optimistic or from the coordinator."""
+        if self._optimistic_value is not None:
+            return self._optimistic_value
+        if self.coordinator.data is None:
+            return None
+        value = _resolve_path(
+            self.coordinator.data, self.entity_description.value_path
+        )
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Send the new value to the SCU."""
+        client = self.coordinator.signalr_client
+        if not client or not client.connected:
+            _LOGGER.warning(
+                "Cannot set %s — SignalR not connected",
+                self.entity_description.key,
+            )
+            return
+        int_value = int(round(value))
+        await client.send_light_command(
+            self.entity_description.bus_id,
+            self.entity_description.sensor_id,
+            uint_value=int_value,
+        )
+        self._optimistic_value = float(int_value)
+        self.async_write_ha_state()
+
+    def _handle_coordinator_update(self) -> None:
+        """Clear optimistic state once the SCU confirms the commanded value."""
+        if self._optimistic_value is not None and self.coordinator.data:
+            value = _resolve_path(
+                self.coordinator.data, self.entity_description.value_path
+            )
+            if value is not None:
+                try:
+                    actual = float(value)
+                except (TypeError, ValueError):
+                    actual = None
+                if actual is not None and actual == self._optimistic_value:
+                    self._optimistic_value = None
+        super()._handle_coordinator_update()

--- a/custom_components/hymer_connect/strings.json
+++ b/custom_components/hymer_connect/strings.json
@@ -151,6 +151,14 @@
       "main_switch_ctrl": { "name": "12V Main switch" },
       "water_pump_ctrl": { "name": "Water pump" },
       "heater_ctrl": { "name": "Heater" }
+    },
+    "button": {
+      "wake_up_chassis_ctrl": { "name": "Wake up chassis" },
+      "update_tank_level_immediately_ctrl": { "name": "Refresh tank levels" },
+      "activate_tank_refill_interval_ctrl": { "name": "Start tank-refill polling" }
+    },
+    "number": {
+      "fridge_level_ctrl": { "name": "Fridge cooling level" }
     }
   }
 }

--- a/custom_components/hymer_connect/translations/en.json
+++ b/custom_components/hymer_connect/translations/en.json
@@ -371,6 +371,22 @@
       "heater_ctrl": {
         "name": "Heater"
       }
+    },
+    "button": {
+      "wake_up_chassis_ctrl": {
+        "name": "Wake up chassis"
+      },
+      "update_tank_level_immediately_ctrl": {
+        "name": "Refresh tank levels"
+      },
+      "activate_tank_refill_interval_ctrl": {
+        "name": "Start tank-refill polling"
+      }
+    },
+    "number": {
+      "fridge_level_ctrl": {
+        "name": "Fridge cooling level"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds two new platforms so the integration exposes a few SCU commands the app has but HA doesn't yet:

**Buttons** (write-only, fire a single command when pressed):

| entity | (bus, sensor) | action |
|-------|---------------|--------|
| Wake up chassis | (30, 11) | cellular \"wake SCU\" poke |
| Refresh tank levels | (3, 21) | force the EBL to sample tanks right now |
| Start tank-refill polling | (3, 20) | enable periodic tank sampling |

**Number**:

| entity | (bus, sensor) | range |
|--------|---------------|-------|
| Fridge cooling level | (34, 3) | integer 1..5, rendered as a slider |

All four use the existing `send_light_command` path, which the earlier PRs confirmed produces byte-perfect PiaRequests for bool and uint writes against captured app traffic.

## Dependency note

The fridge-level `NumberEntity` reads its current value from `signalr_sensors.fridge_level`. That key is created by PR #31, which relabels `(34, 3)` from `heat_mode` to `fridge_level`. Without #31, the slider shows unavailable but *writing* still works — the bus/sensor the command goes to doesn't depend on the key name. The buttons are write-only and have no read dependency.

## Test plan

- [x] `python -c 'import ast; ast.parse(open(f).read())'` for all four touched modules and the two new files
- [x] `strings.json` and `translations/en.json` parse as JSON and cover the four new entity keys
- [ ] Add to a real HA instance, press each button and watch the captured SignalR traffic for the expected PiaRequest (bus/sensor pair, bool=1)
- [ ] Slide the fridge cooling level and verify the fridge responds; confirm `fridge_level` read-back updates (requires #31)

🤖 Generated with [Claude Code](https://claude.com/claude-code)