### PR TITLE
Add select platform for Truma heater power + energy sources

### DIFF
--- a/custom_components/hymer_connect/const.py
+++ b/custom_components/hymer_connect/const.py
@@ -74,4 +74,12 @@ CONF_EHG_TOKEN = "ehg_access_token"
 CONF_EHG_REFRESH_TOKEN = "ehg_refresh_token"
 
 # Platforms
-PLATFORMS = ["sensor", "binary_sensor", "device_tracker", "light", "switch", "select"]
+PLATFORMS = [
+    "sensor",
+    "binary_sensor",
+    "device_tracker",
+    "light",
+    "switch",
+    "select",
+    "number",
+]

--- a/custom_components/hymer_connect/const.py
+++ b/custom_components/hymer_connect/const.py
@@ -74,4 +74,4 @@ CONF_EHG_TOKEN = "ehg_access_token"
 CONF_EHG_REFRESH_TOKEN = "ehg_refresh_token"
 
 # Platforms
-PLATFORMS = ["sensor", "binary_sensor", "device_tracker", "light", "switch"]
+PLATFORMS = ["sensor", "binary_sensor", "device_tracker", "light", "switch", "select"]

--- a/custom_components/hymer_connect/number.py
+++ b/custom_components/hymer_connect/number.py
@@ -1,0 +1,158 @@
+"""Number platform for HYMER Connect — numeric-valued SCU controls.
+
+At present this exposes the Truma heater's target air temperature as a
+HA NumberEntity. The SCU accepts a float °C value on (58, 8); writing
+-273.0 turns the heater off (observed in traffic captures — the app
+uses it as an 'off' sentinel). To avoid users accidentally writing
+-273 through the slider, the entity range is constrained to a normal
+thermostat band.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from homeassistant.components.number import (
+    NumberDeviceClass,
+    NumberEntity,
+    NumberEntityDescription,
+    NumberMode,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTemperature
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, MANUFACTURER
+from .coordinator import HymerConnectCoordinator
+from .pia_decoder import build_sensor_write
+from .sensor import _resolve_path
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class HymerNumberEntityDescription(NumberEntityDescription):
+    """Describe a HYMER Connect number control."""
+
+    bus_id: int
+    sensor_id: int
+    value_path: str
+    # If a "float off sentinel" is set, read-back of that value will be
+    # exposed as None (unknown) instead of the literal sentinel.
+    off_sentinel: float | None = None
+
+
+NUMBER_DESCRIPTIONS: tuple[HymerNumberEntityDescription, ...] = (
+    HymerNumberEntityDescription(
+        key="heater_target_temperature_ctrl",
+        translation_key="heater_target_temperature_ctrl",
+        device_class=NumberDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        native_min_value=5,
+        native_max_value=30,
+        native_step=0.5,
+        mode=NumberMode.SLIDER,
+        bus_id=58,
+        sensor_id=8,
+        value_path="signalr_sensors.heater_setpoint",
+        off_sentinel=-273.0,
+        icon="mdi:thermostat",
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up HYMER Connect number entities from a config entry."""
+    coordinator: HymerConnectCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        HymerConnectNumber(coordinator, desc, entry)
+        for desc in NUMBER_DESCRIPTIONS
+    )
+
+
+class HymerConnectNumber(
+    CoordinatorEntity[HymerConnectCoordinator], NumberEntity
+):
+    """Representation of a HYMER Connect numeric control."""
+
+    entity_description: HymerNumberEntityDescription
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: HymerConnectCoordinator,
+        description: HymerNumberEntityDescription,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the number entity."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{entry.entry_id}_{description.key}"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, entry.entry_id)},
+            "name": f"HYMER {entry.title}",
+            "manufacturer": MANUFACTURER,
+            "model": "Smart Interface Unit",
+        }
+        self._optimistic_value: float | None = None
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the target value currently known for this entity."""
+        if self._optimistic_value is not None:
+            return self._optimistic_value
+        if self.coordinator.data is None:
+            return None
+        raw = _resolve_path(
+            self.coordinator.data, self.entity_description.value_path
+        )
+        if raw is None:
+            return None
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            return None
+        sentinel = self.entity_description.off_sentinel
+        if sentinel is not None and value == sentinel:
+            return None
+        return value
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Send the new value to the SCU."""
+        client = self.coordinator.signalr_client
+        if not client or not client.connected:
+            _LOGGER.warning(
+                "Cannot set %s — SignalR not connected",
+                self.entity_description.key,
+            )
+            return
+        payload = build_sensor_write(
+            self.entity_description.bus_id,
+            self.entity_description.sensor_id,
+            float(value),
+        )
+        await client.send_pia_request(payload)
+        self._optimistic_value = float(value)
+        self.async_write_ha_state()
+
+    def _handle_coordinator_update(self) -> None:
+        """Clear optimistic state once the SCU confirms the commanded value."""
+        if self._optimistic_value is not None and self.coordinator.data:
+            raw = _resolve_path(
+                self.coordinator.data, self.entity_description.value_path
+            )
+            if raw is not None:
+                try:
+                    actual = float(raw)
+                except (TypeError, ValueError):
+                    actual = None
+                if actual is not None and abs(actual - self._optimistic_value) < 0.1:
+                    self._optimistic_value = None
+        super()._handle_coordinator_update()

--- a/custom_components/hymer_connect/pia_decoder.py
+++ b/custom_components/hymer_connect/pia_decoder.py
@@ -282,37 +282,51 @@ def _encode_bytes_field(field_number: int, data: bytes) -> bytes:
     return _encode_field(field_number, 2, _encode_varint(len(data)) + data)
 
 
-def build_light_command(
+def build_sensor_write(
     bus_id: int,
     sensor_id: int,
+    value: bool | int | float | str,
     *,
-    bool_value: bool | None = None,
-    uint_value: int | None = None,
+    signed: bool = False,
 ) -> str:
-    """Build a PiaRequest payload to control a light.
+    """Build a PiaRequest payload to set a single sensor value.
 
-    Args:
-        bus_id: The light's bus ID (e.g. 11 for living ceiling).
-        sensor_id: 1=on/off, 2=brightness, 3=color_temp.
-        bool_value: True/False for on/off (sensor_id=1).
-        uint_value: 0-100 for brightness/color_temp (sensor_id=2,3).
+    The on-the-wire format is the same for every writable sensor the SCU
+    exposes (lights, water pump, fridge level, heater power, etc.): a
+    protobuf-encoded entry that carries the target sensor's bus and sensor
+    numbers plus the value in a datatype-specific field.
 
-    Returns:
-        Base64-encoded protobuf payload ready to send as PiaRequest argument.
+    Python type → protobuf field:
+      * bool      -> field 5 (varint, 0/1) — confirmed via water pump + fridge on/off
+      * int       -> field 3 (unsigned varint) — confirmed via fridge level 1..5
+      * int w/ signed=True -> field 7 (varint signed)
+      * float     -> field 6 (little-endian 32-bit IEEE-754) — confirmed via heater target temp
+      * str       -> field 4 (length-delimited UTF-8) — confirmed via heater energy source
+
+    Returns a Base64 string ready to send as the PiaRequest argument.
     """
-    # Build sensor entry: field1=sensor_id, field2=bus_id, field3/5=value
     sensor_data = _encode_varint_field(1, sensor_id)
     sensor_data += _encode_varint_field(2, bus_id)
-    if bool_value is not None:
-        sensor_data += _encode_varint_field(5, 1 if bool_value else 0)
-    elif uint_value is not None:
-        sensor_data += _encode_varint_field(3, uint_value)
 
-    # Nest: sensor_data inside field1 of sub2, inside field2 of inner
+    if isinstance(value, bool):
+        sensor_data += _encode_varint_field(5, 1 if value else 0)
+    elif isinstance(value, int):
+        if signed:
+            sensor_data += _encode_varint_field(7, value if value >= 0 else (value + (1 << 64)))
+        else:
+            if value < 0:
+                raise ValueError("negative int for unsigned sensor; pass signed=True")
+            sensor_data += _encode_varint_field(3, value)
+    elif isinstance(value, float):
+        sensor_data += _encode_field(6, 5, struct.pack("<f", value))
+    elif isinstance(value, str):
+        sensor_data += _encode_bytes_field(4, value.encode("utf-8"))
+    else:
+        raise TypeError(f"unsupported sensor value type: {type(value).__name__}")
+
     sub2 = _encode_bytes_field(1, sensor_data)
     inner = _encode_bytes_field(2, sub2)
 
-    # Build wrapper: msg_id, version, timestamp, command
     import random
     msg_id = random.randint(1, 10_000_000)
     version_bytes = b"v0.32.0"
@@ -323,10 +337,23 @@ def build_light_command(
     wrapper += _encode_varint_field(3, ts)
     wrapper += _encode_bytes_field(4, inner)
 
-    # Top-level: field 2 = wrapper
     payload = _encode_bytes_field(2, wrapper)
-
     return base64.b64encode(payload).decode("ascii")
+
+
+def build_light_command(
+    bus_id: int,
+    sensor_id: int,
+    *,
+    bool_value: bool | None = None,
+    uint_value: int | None = None,
+) -> str:
+    """Backwards-compatible wrapper for lights; dispatches to build_sensor_write."""
+    if bool_value is not None:
+        return build_sensor_write(bus_id, sensor_id, bool_value)
+    if uint_value is not None:
+        return build_sensor_write(bus_id, sensor_id, int(uint_value))
+    raise ValueError("must provide bool_value or uint_value")
 
 
 def _decode_varint(data: bytes, pos: int) -> tuple[int, int]:

--- a/custom_components/hymer_connect/select.py
+++ b/custom_components/hymer_connect/select.py
@@ -1,0 +1,196 @@
+"""Select platform for HYMER Connect — enum-valued SCU controls.
+
+Used for sensors that accept a small, fixed set of string or integer
+options. The Truma heater exposes three such settings: the electric
+power limit (0/900/1800 W) and two energy-source selectors for the
+air-heating and water-heating subsystems ("Diesel"/"Electric"/"Both").
+
+Each SelectEntity maps friendly UI options onto the raw values the SCU
+expects on the wire.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, MANUFACTURER
+from .coordinator import HymerConnectCoordinator
+from .sensor import _resolve_path
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, kw_only=True)
+class HymerSelectEntityDescription(SelectEntityDescription):
+    """Describe a HYMER Connect select control.
+
+    option_map is an ordered mapping from the UI option label (shown in HA)
+    to the raw value the SCU expects. Values may be int or str.
+    """
+
+    bus_id: int
+    sensor_id: int
+    value_path: str
+    option_map: dict[str, Any] = field(default_factory=dict)
+
+
+SELECT_DESCRIPTIONS: tuple[HymerSelectEntityDescription, ...] = (
+    HymerSelectEntityDescription(
+        key="heater_power_limit_ctrl",
+        translation_key="heater_power_limit_ctrl",
+        bus_id=58,
+        sensor_id=9,
+        value_path="signalr_sensors.heater_electric_power",
+        option_map={"Off": 0, "900 W": 900, "1800 W": 1800},
+        icon="mdi:lightning-bolt",
+    ),
+    HymerSelectEntityDescription(
+        key="heater_air_energy_source_ctrl",
+        translation_key="heater_air_energy_source_ctrl",
+        bus_id=58,
+        sensor_id=4,
+        value_path="signalr_sensors.heater_fuel_type",
+        option_map={"Diesel": "Diesel", "Electric": "Electric", "Both": "Both"},
+        icon="mdi:radiator",
+    ),
+    HymerSelectEntityDescription(
+        key="heater_water_energy_source_ctrl",
+        translation_key="heater_water_energy_source_ctrl",
+        bus_id=58,
+        sensor_id=6,
+        value_path="signalr_sensors.heater_fuel_type_2",
+        option_map={"Diesel": "Diesel", "Electric": "Electric", "Both": "Both"},
+        icon="mdi:water-boiler",
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up HYMER Connect select entities from a config entry."""
+    coordinator: HymerConnectCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        HymerConnectSelect(coordinator, desc, entry)
+        for desc in SELECT_DESCRIPTIONS
+    )
+
+
+class HymerConnectSelect(
+    CoordinatorEntity[HymerConnectCoordinator], SelectEntity
+):
+    """Representation of a HYMER Connect select control."""
+
+    entity_description: HymerSelectEntityDescription
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: HymerConnectCoordinator,
+        description: HymerSelectEntityDescription,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the select."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{entry.entry_id}_{description.key}"
+        self._attr_options = list(description.option_map.keys())
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, entry.entry_id)},
+            "name": f"HYMER {entry.title}",
+            "manufacturer": MANUFACTURER,
+            "model": "Smart Interface Unit",
+        }
+        self._optimistic_option: str | None = None
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the current SCU value as one of the configured options."""
+        if self._optimistic_option is not None:
+            return self._optimistic_option
+        if self.coordinator.data is None:
+            return None
+        value = _resolve_path(
+            self.coordinator.data, self.entity_description.value_path
+        )
+        if value is None:
+            return None
+        for label, raw in self.entity_description.option_map.items():
+            if raw == value:
+                return label
+        return None
+
+    async def async_select_option(self, option: str) -> None:
+        """Write the selected option to the SCU."""
+        raw = self.entity_description.option_map.get(option)
+        if raw is None:
+            _LOGGER.warning(
+                "Unknown option %r for %s",
+                option,
+                self.entity_description.key,
+            )
+            return
+        client = self.coordinator.signalr_client
+        if not client or not client.connected:
+            _LOGGER.warning(
+                "Cannot set %s — SignalR not connected",
+                self.entity_description.key,
+            )
+            return
+
+        if isinstance(raw, bool):
+            await client.send_light_command(
+                self.entity_description.bus_id,
+                self.entity_description.sensor_id,
+                bool_value=raw,
+            )
+        elif isinstance(raw, int):
+            await client.send_light_command(
+                self.entity_description.bus_id,
+                self.entity_description.sensor_id,
+                uint_value=raw,
+            )
+        else:
+            # String option. send_light_command can't express strings; fall
+            # back to the more general build_sensor_write (added in PR #31)
+            # if it's available, otherwise warn.
+            try:
+                from .pia_decoder import build_sensor_write
+            except ImportError:
+                _LOGGER.warning(
+                    "String select not supported on this version of the "
+                    "integration — need build_sensor_write helper."
+                )
+                return
+            payload = build_sensor_write(
+                self.entity_description.bus_id,
+                self.entity_description.sensor_id,
+                raw,
+            )
+            await client.send_pia_request(payload)
+
+        self._optimistic_option = option
+        self.async_write_ha_state()
+
+    def _handle_coordinator_update(self) -> None:
+        """Clear optimistic state when the SCU confirms the commanded option."""
+        if self._optimistic_option is not None and self.coordinator.data:
+            value = _resolve_path(
+                self.coordinator.data, self.entity_description.value_path
+            )
+            expected = self.entity_description.option_map.get(
+                self._optimistic_option
+            )
+            if value is not None and value == expected:
+                self._optimistic_option = None
+        super()._handle_coordinator_update()

--- a/custom_components/hymer_connect/strings.json
+++ b/custom_components/hymer_connect/strings.json
@@ -151,6 +151,11 @@
       "main_switch_ctrl": { "name": "12V Main switch" },
       "water_pump_ctrl": { "name": "Water pump" },
       "heater_ctrl": { "name": "Heater" }
+    },
+    "select": {
+      "heater_power_limit_ctrl": { "name": "Heater electric power" },
+      "heater_air_energy_source_ctrl": { "name": "Heater air energy source" },
+      "heater_water_energy_source_ctrl": { "name": "Heater water energy source" }
     }
   }
 }

--- a/custom_components/hymer_connect/strings.json
+++ b/custom_components/hymer_connect/strings.json
@@ -156,6 +156,9 @@
       "heater_power_limit_ctrl": { "name": "Heater electric power" },
       "heater_air_energy_source_ctrl": { "name": "Heater air energy source" },
       "heater_water_energy_source_ctrl": { "name": "Heater water energy source" }
+    },
+    "number": {
+      "heater_target_temperature_ctrl": { "name": "Heater target temperature" }
     }
   }
 }

--- a/custom_components/hymer_connect/translations/en.json
+++ b/custom_components/hymer_connect/translations/en.json
@@ -371,6 +371,17 @@
       "heater_ctrl": {
         "name": "Heater"
       }
+    },
+    "select": {
+      "heater_power_limit_ctrl": {
+        "name": "Heater electric power"
+      },
+      "heater_air_energy_source_ctrl": {
+        "name": "Heater air energy source"
+      },
+      "heater_water_energy_source_ctrl": {
+        "name": "Heater water energy source"
+      }
     }
   }
 }

--- a/custom_components/hymer_connect/translations/en.json
+++ b/custom_components/hymer_connect/translations/en.json
@@ -382,6 +382,11 @@
       "heater_water_energy_source_ctrl": {
         "name": "Heater water energy source"
       }
+    },
+    "number": {
+      "heater_target_temperature_ctrl": {
+        "name": "Heater target temperature"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds a \`select\` platform with three entities for the Truma heater:

| entity | (bus, sensor) | options |
|--------|---------------|---------|
| Heater electric power | (58, 9) | Off / 900 W / 1800 W (uint write) |
| Heater air energy source | (58, 4) | Diesel / Electric / Both (string write) |
| Heater water energy source | (58, 6) | Diesel / Electric / Both (string write) |

## Verification

Live capture while setting each value in the mobile app. Writes captured:

\`\`\`
(58, 9)=uint:900       from \"900 W\"
(58, 9)=uint:1800      from \"1800 W\"
(58, 4)=string:'Diesel' from \"Diesel\"
(58, 4)=string:'Both'   from \"Both\"
(58, 6)=string:'Diesel' from mirrored change
(58, 8)=float:-273.0    from turning the heater off (sentinel)
(58, 8)=float:18.0      from target-temperature 18 °C
(58, 8)=float:22.0      from target-temperature 22 °C
\`\`\`

The inner PIA entry bytes produced by this integration's \`build_sensor_write\` match the captured bytes byte-for-byte for uint, string, and float writes. (The float writes aren't part of this PR — a heater target-temperature NumberEntity is a natural follow-up.)

## Dependency

The string writes (air / water energy source) use \`build_sensor_write\`, which is introduced in PR #31. The \`select.py\` module imports it lazily and logs a warning if it isn't available, so this PR can merge without #31 — only the Power-limit entity (uint) will work in that case. Once #31 merges, all three selects are fully functional.

## Test plan

- [x] \`python -c 'import ast; ast.parse(open(f).read())'\` for select.py + const.py
- [x] \`strings.json\` + \`translations/en.json\` parse as JSON and cover the three new select keys
- [x] Live captures of setting each option in the official app produce the exact same inner PIA bytes that this module would generate
- [ ] Add to a real HA instance and verify each select writes the expected command (and reads-back the current value once it round-trips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)